### PR TITLE
fix: update section management tools to handle YAML string input

### DIFF
--- a/agents/generate/page-data/compose-pages-data.mjs
+++ b/agents/generate/page-data/compose-pages-data.mjs
@@ -141,7 +141,9 @@ function remapIdsInPlace(obj, fromId, toId) {
     remapped.forEach((x) => obj.push(x));
   } else if (obj && typeof obj === "object") {
     Object.keys(obj).forEach((k) => delete obj[k]);
-    Object.entries(remapped).forEach(([k, v]) => (obj[k] = v));
+    Object.entries(remapped).forEach(([k, v]) => {
+      obj[k] = v;
+    });
   }
   log("🔁 [remapIdsInPlace] remapped:", { fromId, toId });
 }

--- a/agents/update/page-detail-tools/add-section.mjs
+++ b/agents/update/page-detail-tools/add-section.mjs
@@ -30,7 +30,10 @@ export default async function addSection({ pageDetail, section, position }) {
   try {
     parsedSection = YAML.parse(section);
   } catch (error) {
-    console.log("⚠️  Unable to parse section YAML:", error.message);
+    console.log(
+      "⚠️  Unable to parse section YAML. Please ensure valid YAML format with proper indentation:",
+      error.message,
+    );
     return { pageDetail };
   }
 

--- a/agents/update/page-detail-tools/add-section.mjs
+++ b/agents/update/page-detail-tools/add-section.mjs
@@ -25,8 +25,17 @@ export default async function addSection({ pageDetail, section, position }) {
     return { pageDetail };
   }
 
+  // Parse section YAML string to object
+  let parsedSection;
+  try {
+    parsedSection = YAML.parse(section);
+  } catch (error) {
+    console.log("⚠️  Unable to parse section YAML:", error.message);
+    return { pageDetail };
+  }
+
   // Validate section has required properties
-  if (!section.name) {
+  if (!parsedSection.name) {
     console.log(
       "⚠️  Unable to add section: Section must have a name. Please provide a unique name for the section.",
     );
@@ -39,10 +48,10 @@ export default async function addSection({ pageDetail, section, position }) {
   }
 
   // Check if section with same name already exists
-  const existingSection = parsedPageDetail.sections.find((s) => s.name === section.name);
+  const existingSection = parsedPageDetail.sections.find((s) => s.name === parsedSection.name);
   if (existingSection) {
     console.log(
-      `⚠️  Unable to add section: A section with name '${section.name}' already exists. Please choose a different name for the new section.`,
+      `⚠️  Unable to add section: A section with name '${parsedSection.name}' already exists. Please choose a different name for the new section.`,
     );
     return { pageDetail };
   }
@@ -65,7 +74,7 @@ export default async function addSection({ pageDetail, section, position }) {
 
   // Create new sections array with the inserted section
   const newSections = [...parsedPageDetail.sections];
-  newSections.splice(insertIndex, 0, section);
+  newSections.splice(insertIndex, 0, parsedSection);
 
   // Create updated page detail
   const updatedPageDetail = {
@@ -78,7 +87,7 @@ export default async function addSection({ pageDetail, section, position }) {
       quotingType: '"',
       defaultStringType: "QUOTE_DOUBLE",
     }),
-    addedSection: section,
+    addedSection: parsedSection,
     insertedAt: insertIndex,
   };
 }
@@ -93,15 +102,9 @@ addSection.inputSchema = {
       description: "Current page detail YAML string",
     },
     section: {
-      type: "object",
-      description: "Section content to add with at least a name property",
-      properties: {
-        name: { type: "string" },
-        summary: { type: "string" },
-        title: { type: "string" },
-        description: { type: "string" },
-      },
-      required: ["name"],
+      type: "string",
+      description:
+        "YAML string containing the section content to add (must include a 'name' property). Any valid section properties can be included (e.g., 'name: section1\\ntitle: My Title\\ndescription: My description').",
     },
     position: {
       type: ["number", "string"],

--- a/agents/update/page-detail-tools/update-section.mjs
+++ b/agents/update/page-detail-tools/update-section.mjs
@@ -1,18 +1,6 @@
 import YAML from "yaml";
 
-// FIXME: Update this function when new properties are added to built-in components.
-// Currently supported properties must be manually added to the updates object below.
-export default async function updateSection({
-  pageDetail,
-  name,
-  title,
-  description,
-  image,
-  code,
-  action,
-  list,
-  summary,
-}) {
+export default async function updateSection({ pageDetail, name, updates }) {
   // Validate required parameters
   if (!pageDetail) {
     console.log("⚠️  Update failed: Missing required page detail parameter");
@@ -33,20 +21,22 @@ export default async function updateSection({
     return { pageDetail };
   }
 
-  // Define supported update fields and collect provided values
-  const updates = {};
+  if (!updates) {
+    console.log("⚠️  Update failed: Missing required updates parameter");
+    return { pageDetail };
+  }
 
-  // Only include defined (non-undefined) supported fields
-  if (title !== undefined) updates.title = title;
-  if (description !== undefined) updates.description = description;
-  if (image !== undefined) updates.image = image;
-  if (code !== undefined) updates.code = code;
-  if (action !== undefined) updates.action = action;
-  if (list !== undefined) updates.list = list;
-  if (summary !== undefined) updates.summary = summary;
+  // Parse updates YAML string to object
+  let parsedUpdates;
+  try {
+    parsedUpdates = YAML.parse(updates);
+  } catch (error) {
+    console.log("⚠️  Unable to parse updates YAML:", error.message);
+    return { pageDetail };
+  }
 
   // Check if any update fields are provided
-  const updateFields = Object.keys(updates);
+  const updateFields = Object.keys(parsedUpdates);
   if (updateFields.length === 0) {
     console.log("⚠️  Update failed: No section properties specified for update");
     return { pageDetail };
@@ -70,7 +60,7 @@ export default async function updateSection({
   // Create updated section object
   const updatedSection = {
     ...originalSection,
-    ...updates,
+    ...parsedUpdates,
   };
 
   // Create new sections array with the updated section
@@ -106,20 +96,13 @@ updateSection.inputSchema = {
       type: "string",
       description: "Name of the section to update",
     },
-    summary: {
+    updates: {
       type: "string",
-      description: "New section summary (optional)",
-    },
-    title: {
-      type: "string",
-      description: "New section title (optional)",
-    },
-    description: {
-      type: "string",
-      description: "New section description (optional)",
+      description:
+        "YAML string containing the properties to update (e.g., 'title: New Title\\ndescription: New description'). Any valid section properties can be included.",
     },
   },
-  required: ["pageDetail", "name"],
+  required: ["pageDetail", "name", "updates"],
 };
 updateSection.outputSchema = {
   type: "object",

--- a/agents/update/page-detail-tools/update-section.mjs
+++ b/agents/update/page-detail-tools/update-section.mjs
@@ -31,7 +31,10 @@ export default async function updateSection({ pageDetail, name, updates }) {
   try {
     parsedUpdates = YAML.parse(updates);
   } catch (error) {
-    console.log("⚠️  Unable to parse updates YAML:", error.message);
+    console.log(
+      "⚠️  Invalid YAML format in updates parameter. Please ensure it follows valid YAML syntax:",
+      error.message,
+    );
     return { pageDetail };
   }
 
@@ -99,7 +102,7 @@ updateSection.inputSchema = {
     updates: {
       type: "string",
       description:
-        "YAML string containing the properties to update (e.g., 'title: New Title\\ndescription: New description'). Any valid section properties can be included.",
+        "YAML string containing the properties to update. Example: 'title: New Title\ndescription: New Description'. All valid section properties are supported.",
     },
   },
   required: ["pageDetail", "name", "updates"],

--- a/agents/update/user-review-page-detail.mjs
+++ b/agents/update/user-review-page-detail.mjs
@@ -163,53 +163,161 @@ function printPageDetail(pageDetail) {
 function printSectionSimple(section, index) {
   console.log(`\nSection ${index}`);
 
-  // Extract and display key content fields
+  // Print all fields except 'name' and 'summary' with recursive handling
   const content = [];
+  const excludeFields = ['name', 'summary'];
 
-  // FIXME: Update this function when new properties are added to built-in components.
-  // Currently supported properties must be manually added to the content array below.
-  if (section.title) content.push(`Title: ${truncateText(section.title, 80)}`);
-  if (section.description) content.push(`Description: ${truncateText(section.description, 80)}`);
-  if (section.image) content.push(`🖼️ Image`);
-  if (section.code) content.push(`💻 Code`);
-  if (section.action) {
-    const actionText = typeof section.action === "object" ? section.action.text : section.action;
-    content.push(`🔘 ${truncateText(actionText || "Button", 30)}`);
-  }
-  if (section.list && Array.isArray(section.list)) {
-    const listDetails = section.list
-      .map((item, index) => {
-        if (typeof item === "string") {
-          return `${index + 1}. ${truncateText(item, 40)}`;
-        } else if (typeof item === "object" && item !== null) {
-          const itemTitle = item.title || item.name || item.text || "Item";
-          const itemDesc = item.description || item.summary || "";
-          return `${index + 1}. ${truncateText(itemTitle, 25)}${itemDesc ? ` - ${truncateText(itemDesc, 50)}` : ""}`;
-        }
-        return `${index + 1}. ${truncateText(String(item), 40)}`;
-      })
-      .join("\n     ");
-    content.push(`📋 List (${section.list.length} items):\n     ${listDetails}`);
-  }
+  Object.keys(section)
+    .filter(key => !excludeFields.includes(key))
+    .forEach(key => {
+      const value = section[key];
+      const displayText = formatFieldValue(key, value);
+      if (displayText) {
+        content.push(displayText);
+      }
+    });
 
   // Show content in a compact format
   if (content.length > 0) {
     const contentLine = content.join("\n   ");
     console.log(`   ${contentLine}`);
   }
+}
 
-  // Show any custom fields
-  const customFields = Object.keys(section).filter(
-    (key) =>
-      !["name", "summary", "title", "description", "image", "code", "action", "list"].includes(key),
-  );
-
-  if (customFields.length > 0) {
-    const customText = customFields
-      .map((key) => `${key}: ${truncateText(String(section[key]), 15)}`)
-      .join(" • ");
-    console.log(`   📎 ${truncateText(customText, 50)}`);
+function formatFieldValue(key, value, indent = "") {
+  if (value === null || value === undefined) {
+    return null;
   }
+
+  const displayName = getDisplayName(key);
+
+  if (typeof value === 'string') {
+    // Special handling for code fields - just show existence
+    if (key.toLowerCase().includes('code') || key.toLowerCase().includes('snippet')) {
+      const prefix = displayName ? `${displayName}` : "💻 Code";
+      return `${indent}${prefix}`;
+    }
+
+    const prefix = displayName ? `${displayName}: ` : "";
+    return `${indent}${prefix}${truncateText(value, 80)}`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    const prefix = displayName ? `${displayName}: ` : "";
+    return `${indent}${prefix}${value}`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      const prefix = displayName ? `${displayName}: ` : "";
+      return `${indent}${prefix}[]`;
+    }
+
+    const listHeader = displayName ? `${displayName} (${value.length} items):` : `List (${value.length} items):`;
+    const listItems = value.map((item, index) => {
+      if (typeof item === 'string') {
+        return `${indent}     ${index + 1}. ${truncateText(item, 80)}`;
+      } else if (typeof item === 'object' && item !== null) {
+        const subContent = Object.keys(item)
+          .filter(subKey => !['name', 'summary'].includes(subKey))
+          .map(subKey => formatFieldValue(subKey, item[subKey], "       "))
+          .filter(Boolean)
+          .join("\n");
+        return `${indent}     ${index + 1}. \n${subContent || 'Item'}`;
+      } else {
+        return `${indent}     ${index + 1}. ${truncateText(String(item), 80)}`;
+      }
+    }).join("\n");
+
+    return `${indent}📋 ${listHeader}\n${listItems}`;
+  }
+
+  if (typeof value === 'object') {
+    // Special handling for code objects - just show existence
+    if (key.toLowerCase().includes('code') || key.toLowerCase().includes('snippet')) {
+      const prefix = displayName ? `${displayName}` : "💻 Code";
+      return `${indent}${prefix}`;
+    }
+
+    const subContent = Object.keys(value)
+      .filter(subKey => !['name', 'summary'].includes(subKey))
+      .map(subKey => formatFieldValue(subKey, value[subKey], `${indent}   `))
+      .filter(Boolean)
+      .join("\n");
+
+    if (subContent) {
+      const prefix = displayName ? `${displayName}:` : "Object:";
+      return `${indent}${prefix}\n${subContent}`;
+    } else {
+      const prefix = displayName ? `${displayName}: ` : "";
+      return `${indent}${prefix}{}`;
+    }
+  }
+
+  const prefix = displayName ? `${displayName}: ` : "";
+  return `${indent}${prefix}${truncateText(String(value), 80)}`;
+}
+
+function getDisplayName(fieldName) {
+  const fieldMappings = [
+    // Title related - ordered by priority
+    { pattern: 'title', display: 'Title' },
+    { pattern: 'heading', display: 'Title' },
+    { pattern: 'header', display: 'Title' },
+
+    // Description related
+    { pattern: 'description', display: 'Description' },
+    { pattern: 'desc', display: 'Description' },
+    { pattern: 'content', display: 'Content' },
+    { pattern: 'text', display: 'Text' },
+    { pattern: 'body', display: 'Content' },
+
+    // Media related
+    { pattern: 'image', display: '🖼️ Image' },
+    { pattern: 'img', display: '🖼️ Image' },
+    { pattern: 'picture', display: '🖼️ Image' },
+    { pattern: 'photo', display: '🖼️ Photo' },
+    { pattern: 'video', display: '🎥 Video' },
+    { pattern: 'audio', display: '🔊 Audio' },
+
+    // Interactive elements
+    { pattern: 'action', display: '🔘 Action' },
+    { pattern: 'button', display: '🔘 Button' },
+    { pattern: 'link', display: '🔗 Link' },
+    { pattern: 'url', display: '🔗 URL' },
+    { pattern: 'href', display: '🔗 Link' },
+
+    // Code related
+    { pattern: 'code', display: '💻 Code' },
+    { pattern: 'snippet', display: '💻 Code' },
+    { pattern: 'script', display: '💻 Script' },
+
+    // List related
+    { pattern: 'list', display: 'List' },
+    { pattern: 'items', display: 'Items' },
+    { pattern: 'options', display: 'Options' },
+
+    // Common properties
+    { pattern: 'id', display: 'ID' },
+    { pattern: 'type', display: 'Type' },
+    { pattern: 'style', display: 'Style' },
+    { pattern: 'class', display: 'Class' },
+    { pattern: 'value', display: 'Value' },
+    { pattern: 'placeholder', display: 'Placeholder' },
+    { pattern: 'label', display: 'Label' },
+  ];
+
+  const lowerField = fieldName.toLowerCase();
+
+  // Check for partial matches - find first matching pattern
+  for (const { pattern, display } of fieldMappings) {
+    if (lowerField.includes(pattern.toLowerCase())) {
+      return display;
+    }
+  }
+
+  // If no match found, return null to show value without field name
+  return null;
 }
 
 function truncateText(text, maxLength) {

--- a/agents/update/user-review-page-detail.mjs
+++ b/agents/update/user-review-page-detail.mjs
@@ -165,11 +165,11 @@ function printSectionSimple(section, index) {
 
   // Print all fields except 'name' and 'summary' with recursive handling
   const content = [];
-  const excludeFields = ['name', 'summary'];
+  const excludeFields = ["name", "summary"];
 
   Object.keys(section)
-    .filter(key => !excludeFields.includes(key))
-    .forEach(key => {
+    .filter((key) => !excludeFields.includes(key))
+    .forEach((key) => {
       const value = section[key];
       const displayText = formatFieldValue(key, value);
       if (displayText) {
@@ -191,9 +191,9 @@ function formatFieldValue(key, value, indent = "") {
 
   const displayName = getDisplayName(key);
 
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     // Special handling for code fields - just show existence
-    if (key.toLowerCase().includes('code') || key.toLowerCase().includes('snippet')) {
+    if (key.toLowerCase().includes("code") || key.toLowerCase().includes("snippet")) {
       const prefix = displayName ? `${displayName}` : "💻 Code";
       return `${indent}${prefix}`;
     }
@@ -202,7 +202,7 @@ function formatFieldValue(key, value, indent = "") {
     return `${indent}${prefix}${truncateText(value, 80)}`;
   }
 
-  if (typeof value === 'number' || typeof value === 'boolean') {
+  if (typeof value === "number" || typeof value === "boolean") {
     const prefix = displayName ? `${displayName}: ` : "";
     return `${indent}${prefix}${value}`;
   }
@@ -213,35 +213,39 @@ function formatFieldValue(key, value, indent = "") {
       return `${indent}${prefix}[]`;
     }
 
-    const listHeader = displayName ? `${displayName} (${value.length} items):` : `List (${value.length} items):`;
-    const listItems = value.map((item, index) => {
-      if (typeof item === 'string') {
-        return `${indent}     ${index + 1}. ${truncateText(item, 80)}`;
-      } else if (typeof item === 'object' && item !== null) {
-        const subContent = Object.keys(item)
-          .filter(subKey => !['name', 'summary'].includes(subKey))
-          .map(subKey => formatFieldValue(subKey, item[subKey], "       "))
-          .filter(Boolean)
-          .join("\n");
-        return `${indent}     ${index + 1}. \n${subContent || 'Item'}`;
-      } else {
-        return `${indent}     ${index + 1}. ${truncateText(String(item), 80)}`;
-      }
-    }).join("\n");
+    const listHeader = displayName
+      ? `${displayName} (${value.length} items):`
+      : `List (${value.length} items):`;
+    const listItems = value
+      .map((item, index) => {
+        if (typeof item === "string") {
+          return `${indent}     ${index + 1}. ${truncateText(item, 80)}`;
+        } else if (typeof item === "object" && item !== null) {
+          const subContent = Object.keys(item)
+            .filter((subKey) => !["name", "summary"].includes(subKey))
+            .map((subKey) => formatFieldValue(subKey, item[subKey], "       "))
+            .filter(Boolean)
+            .join("\n");
+          return `${indent}     ${index + 1}. \n${subContent || "Item"}`;
+        } else {
+          return `${indent}     ${index + 1}. ${truncateText(String(item), 80)}`;
+        }
+      })
+      .join("\n");
 
     return `${indent}📋 ${listHeader}\n${listItems}`;
   }
 
-  if (typeof value === 'object') {
+  if (typeof value === "object") {
     // Special handling for code objects - just show existence
-    if (key.toLowerCase().includes('code') || key.toLowerCase().includes('snippet')) {
+    if (key.toLowerCase().includes("code") || key.toLowerCase().includes("snippet")) {
       const prefix = displayName ? `${displayName}` : "💻 Code";
       return `${indent}${prefix}`;
     }
 
     const subContent = Object.keys(value)
-      .filter(subKey => !['name', 'summary'].includes(subKey))
-      .map(subKey => formatFieldValue(subKey, value[subKey], `${indent}   `))
+      .filter((subKey) => !["name", "summary"].includes(subKey))
+      .map((subKey) => formatFieldValue(subKey, value[subKey], `${indent}   `))
       .filter(Boolean)
       .join("\n");
 
@@ -261,50 +265,50 @@ function formatFieldValue(key, value, indent = "") {
 function getDisplayName(fieldName) {
   const fieldMappings = [
     // Title related - ordered by priority
-    { pattern: 'title', display: 'Title' },
-    { pattern: 'heading', display: 'Title' },
-    { pattern: 'header', display: 'Title' },
+    { pattern: "title", display: "Title" },
+    { pattern: "heading", display: "Title" },
+    { pattern: "header", display: "Title" },
 
     // Description related
-    { pattern: 'description', display: 'Description' },
-    { pattern: 'desc', display: 'Description' },
-    { pattern: 'content', display: 'Content' },
-    { pattern: 'text', display: 'Text' },
-    { pattern: 'body', display: 'Content' },
+    { pattern: "description", display: "Description" },
+    { pattern: "desc", display: "Description" },
+    { pattern: "content", display: "Content" },
+    { pattern: "text", display: "Text" },
+    { pattern: "body", display: "Content" },
 
     // Media related
-    { pattern: 'image', display: '🖼️ Image' },
-    { pattern: 'img', display: '🖼️ Image' },
-    { pattern: 'picture', display: '🖼️ Image' },
-    { pattern: 'photo', display: '🖼️ Photo' },
-    { pattern: 'video', display: '🎥 Video' },
-    { pattern: 'audio', display: '🔊 Audio' },
+    { pattern: "image", display: "🖼️ Image" },
+    { pattern: "img", display: "🖼️ Image" },
+    { pattern: "picture", display: "🖼️ Image" },
+    { pattern: "photo", display: "🖼️ Photo" },
+    { pattern: "video", display: "🎥 Video" },
+    { pattern: "audio", display: "🔊 Audio" },
 
     // Interactive elements
-    { pattern: 'action', display: '🔘 Action' },
-    { pattern: 'button', display: '🔘 Button' },
-    { pattern: 'link', display: '🔗 Link' },
-    { pattern: 'url', display: '🔗 URL' },
-    { pattern: 'href', display: '🔗 Link' },
+    { pattern: "action", display: "🔘 Action" },
+    { pattern: "button", display: "🔘 Button" },
+    { pattern: "link", display: "🔗 Link" },
+    { pattern: "url", display: "🔗 URL" },
+    { pattern: "href", display: "🔗 Link" },
 
     // Code related
-    { pattern: 'code', display: '💻 Code' },
-    { pattern: 'snippet', display: '💻 Code' },
-    { pattern: 'script', display: '💻 Script' },
+    { pattern: "code", display: "💻 Code" },
+    { pattern: "snippet", display: "💻 Code" },
+    { pattern: "script", display: "💻 Script" },
 
     // List related
-    { pattern: 'list', display: 'List' },
-    { pattern: 'items', display: 'Items' },
-    { pattern: 'options', display: 'Options' },
+    { pattern: "list", display: "List" },
+    { pattern: "items", display: "Items" },
+    { pattern: "options", display: "Options" },
 
     // Common properties
-    { pattern: 'id', display: 'ID' },
-    { pattern: 'type', display: 'Type' },
-    { pattern: 'style', display: 'Style' },
-    { pattern: 'class', display: 'Class' },
-    { pattern: 'value', display: 'Value' },
-    { pattern: 'placeholder', display: 'Placeholder' },
-    { pattern: 'label', display: 'Label' },
+    { pattern: "id", display: "ID" },
+    { pattern: "type", display: "Type" },
+    { pattern: "style", display: "Style" },
+    { pattern: "class", display: "Class" },
+    { pattern: "value", display: "Value" },
+    { pattern: "placeholder", display: "Placeholder" },
+    { pattern: "label", display: "Label" },
   ];
 
   const lowerField = fieldName.toLowerCase();

--- a/agents/update/user-review-page-detail.mjs
+++ b/agents/update/user-review-page-detail.mjs
@@ -262,55 +262,54 @@ function formatFieldValue(key, value, indent = "") {
   return `${indent}${prefix}${truncateText(String(value), 80)}`;
 }
 
+const fieldMappings = [
+  // Title related - ordered by priority
+  { pattern: "title", display: "Title" },
+  { pattern: "heading", display: "Title" },
+  { pattern: "header", display: "Title" },
+
+  // Description related
+  { pattern: "description", display: "Description" },
+  { pattern: "desc", display: "Description" },
+  { pattern: "content", display: "Content" },
+  { pattern: "text", display: "Text" },
+  { pattern: "body", display: "Content" },
+
+  // Media related
+  { pattern: "image", display: "🖼️ Image" },
+  { pattern: "img", display: "🖼️ Image" },
+  { pattern: "picture", display: "🖼️ Image" },
+  { pattern: "photo", display: "🖼️ Photo" },
+  { pattern: "video", display: "🎥 Video" },
+  { pattern: "audio", display: "🔊 Audio" },
+
+  // Interactive elements
+  { pattern: "action", display: "🔘 Action" },
+  { pattern: "button", display: "🔘 Button" },
+  { pattern: "link", display: "🔗 Link" },
+  { pattern: "url", display: "🔗 URL" },
+  { pattern: "href", display: "🔗 Link" },
+
+  // Code related
+  { pattern: "code", display: "💻 Code" },
+  { pattern: "snippet", display: "💻 Code" },
+  { pattern: "script", display: "💻 Script" },
+
+  // List related
+  { pattern: "list", display: "List" },
+  { pattern: "items", display: "Items" },
+  { pattern: "options", display: "Options" },
+
+  // Common properties
+  { pattern: "id", display: "ID" },
+  { pattern: "type", display: "Type" },
+  { pattern: "style", display: "Style" },
+  { pattern: "class", display: "Class" },
+  { pattern: "value", display: "Value" },
+  { pattern: "placeholder", display: "Placeholder" },
+  { pattern: "label", display: "Label" },
+];
 function getDisplayName(fieldName) {
-  const fieldMappings = [
-    // Title related - ordered by priority
-    { pattern: "title", display: "Title" },
-    { pattern: "heading", display: "Title" },
-    { pattern: "header", display: "Title" },
-
-    // Description related
-    { pattern: "description", display: "Description" },
-    { pattern: "desc", display: "Description" },
-    { pattern: "content", display: "Content" },
-    { pattern: "text", display: "Text" },
-    { pattern: "body", display: "Content" },
-
-    // Media related
-    { pattern: "image", display: "🖼️ Image" },
-    { pattern: "img", display: "🖼️ Image" },
-    { pattern: "picture", display: "🖼️ Image" },
-    { pattern: "photo", display: "🖼️ Photo" },
-    { pattern: "video", display: "🎥 Video" },
-    { pattern: "audio", display: "🔊 Audio" },
-
-    // Interactive elements
-    { pattern: "action", display: "🔘 Action" },
-    { pattern: "button", display: "🔘 Button" },
-    { pattern: "link", display: "🔗 Link" },
-    { pattern: "url", display: "🔗 URL" },
-    { pattern: "href", display: "🔗 Link" },
-
-    // Code related
-    { pattern: "code", display: "💻 Code" },
-    { pattern: "snippet", display: "💻 Code" },
-    { pattern: "script", display: "💻 Script" },
-
-    // List related
-    { pattern: "list", display: "List" },
-    { pattern: "items", display: "Items" },
-    { pattern: "options", display: "Options" },
-
-    // Common properties
-    { pattern: "id", display: "ID" },
-    { pattern: "type", display: "Type" },
-    { pattern: "style", display: "Style" },
-    { pattern: "class", display: "Class" },
-    { pattern: "value", display: "Value" },
-    { pattern: "placeholder", display: "Placeholder" },
-    { pattern: "label", display: "Label" },
-  ];
-
   const lowerField = fieldName.toLowerCase();
 
   // Check for partial matches - find first matching pattern

--- a/agents/utils/choose-pages.mjs
+++ b/agents/utils/choose-pages.mjs
@@ -20,7 +20,7 @@ function createFileChoice(fileName, websiteStructureResult) {
   const foundItem = findItemByFlatName(websiteStructureResult, flatName);
 
   if (foundItem?.title) {
-    // Show title with path for context: "Home (/home)"
+    // Show title with path for context: "Home"
     const displayName = foundItem.title;
     return {
       name: displayName,

--- a/agents/utils/choose-pages.mjs
+++ b/agents/utils/choose-pages.mjs
@@ -1,11 +1,39 @@
 import { join } from "node:path";
 import {
   addFeedbackToItems,
+  fileNameToFlatPath,
+  findItemByFlatName,
   findItemByPath,
   getActionText,
   getMainLanguageFiles,
   processSelectedFiles,
 } from "../../utils/pages-finder-utils.mjs";
+
+/**
+ * Create file choice with title display
+ * @param {string} fileName - File name
+ * @param {Array} websiteStructureResult - Website structure data
+ * @returns {Object} Choice object with name and value
+ */
+function createFileChoice(fileName, websiteStructureResult) {
+  const flatName = fileNameToFlatPath(fileName);
+  const foundItem = findItemByFlatName(websiteStructureResult, flatName);
+
+  if (foundItem?.title) {
+    // Show title with path for context: "Home (/home)"
+    const displayName = foundItem.title;
+    return {
+      name: displayName,
+      value: fileName,
+    };
+  }
+
+  // Fallback to filename if no title found
+  return {
+    name: fileName,
+    value: fileName,
+  };
+}
 
 /**
  * Choose pages for processing
@@ -55,16 +83,16 @@ export default async function choosePages(
         throw new Error("No pages found in the pages directory");
       }
 
+      // Generate choices once outside the source function
+      const choices = mainLanguageFiles.map((file) =>
+        createFileChoice(file, websiteStructureResult),
+      );
+
       // Let user select files (single or multiple based on multipleSelection parameter)
       if (multipleSelection) {
         selectedFiles = await options.prompts.checkbox({
           message: getActionText(isTranslate, "Select pages to {action}:"),
           source: (term) => {
-            const choices = mainLanguageFiles.map((file) => ({
-              name: file,
-              value: file,
-            }));
-
             if (!term) return choices;
 
             return choices.filter((choice) =>
@@ -82,11 +110,6 @@ export default async function choosePages(
         const selectedFile = await options.prompts.search({
           message: getActionText(isTranslate, "Select page to {action}:"),
           source: (term) => {
-            const choices = mainLanguageFiles.map((file) => ({
-              name: file,
-              value: file,
-            }));
-
             if (!term) return choices;
 
             return choices.filter((choice) =>


### PR DESCRIPTION
## Related Issue
https://team.arcblock.io/comment/discussions/y5t80V1hDtjrAnR7-w3Dj4pGqztATrdKR#51016b58-283e-483a-a90c-499486724630


### Major Changes

1. 优化页面选择时，页面列表的展示，改为显示页面标题
2. 优化 updateSection、addSection Tool 的实现，支持动态属性

### Screenshots

<img width="583" height="301" alt="image" src="https://github.com/user-attachments/assets/6a1a49a0-59c9-4f7d-a623-c51db3d558b6" />


### Test Plan

- [x] 验证选择文档，文档列表展示的修改
- [x] 回归 update 命令中新增 section 、编辑 section 、删除 section

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- Refactor: Improved section management with more robust YAML handling for adding and updating page sections
- Enhancement: Better user experience when selecting pages, now showing page titles instead of filenames
- Enhancement: More readable display of page information with improved formatting and labels
- Refactor: Streamlined internal page data handling for better maintainability

These changes focus on making the page management interface more user-friendly and robust, while maintaining existing functionality. Users will notice clearer page selection options and better formatted page information displays.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->