### PR TITLE
feat: add paid website deployment service integration

### DIFF
--- a/.aigne/web-smith/config.yaml
+++ b/.aigne/web-smith/config.yaml
@@ -60,4 +60,5 @@ pagesDir: .aigne/web-smith/pages # Directory to save generated pages
 sourcesPath: # Source code paths to analyze
   - ./
 lastGitHead: b365df20e405d069a47d5c9ed9cca71f1635712b
-appUrl: https://staging.websmith.aigne.io/
+# Checkout ID for website deployment service
+checkoutId: ""

--- a/.aigne/web-smith/config.yaml
+++ b/.aigne/web-smith/config.yaml
@@ -62,3 +62,4 @@ sourcesPath: # Source code paths to analyze
 lastGitHead: b365df20e405d069a47d5c9ed9cca71f1635712b
 # Checkout ID for website deployment service
 checkoutId: ""
+appUrl: https://staging.websmith.aigne.io/

--- a/agents/publish/publish-website.mjs
+++ b/agents/publish/publish-website.mjs
@@ -224,13 +224,13 @@ export default async function publishWebsite(
         ...(hasCachedCheckoutId
           ? [
               {
-                name: `${chalk.yellow("Resume previous website setup")} - ${chalk.green("Already paid.")} Continue where you left off. Your payment is already processed.`,
+                name: `${chalk.yellow("Resume previous website setup")} - ${chalk.green("Already paid.")} Continue where you left off. Your payment has already been processed.`,
                 value: "new-pagekit-continue",
               },
             ]
           : []),
         {
-          name: `${chalk.blue("New dedicated website")} - ${chalk.yellow("Paid service.")} We'll create a brand-new website with custom domain and hosting. Perfect for professional use.`,
+          name: `${chalk.blue("New dedicated website")} - ${chalk.yellow("Paid service.")} Create a new website with custom domain and hosting for professional use.`,
           value: "new-pagekit",
         },
       ],

--- a/agents/publish/publish-website.mjs
+++ b/agents/publish/publish-website.mjs
@@ -210,7 +210,6 @@ export default async function publishWebsite(
 
   if (!useEnvAppUrl && isDefaultAppUrl && !hasAppUrlInConfig) {
     const hasCachedCheckoutId = !!config?.checkoutId;
-    const hasWebSmithBaseUrl = !!process.env.WEB_SMITH_BASE_URL;
     const choice = await options.prompts.select({
       message: "Select platform to publish your pages:",
       choices: [
@@ -222,7 +221,7 @@ export default async function publishWebsite(
           name: `${chalk.blue("Your existing website")} - Integrate and publish directly on your current site (setup required)`,
           value: "custom",
         },
-        ...(hasCachedCheckoutId && hasWebSmithBaseUrl
+        ...(hasCachedCheckoutId
           ? [
               {
                 name: `${chalk.yellow("Resume previous website setup")} - ${chalk.green("Already paid.")} Continue where you left off. Your payment is already processed.`,
@@ -230,14 +229,10 @@ export default async function publishWebsite(
               },
             ]
           : []),
-        ...(hasWebSmithBaseUrl
-          ? [
-              {
-                name: `${chalk.blue("New dedicated website")} - ${chalk.yellow("Paid service.")} We'll create a brand-new website with custom domain and hosting. Perfect for professional use.`,
-                value: "new-pagekit",
-              },
-            ]
-          : []),
+        {
+          name: `${chalk.blue("New dedicated website")} - ${chalk.yellow("Paid service.")} We'll create a brand-new website with custom domain and hosting. Perfect for professional use.`,
+          value: "new-pagekit",
+        },
       ],
     });
 
@@ -261,7 +256,7 @@ export default async function publishWebsite(
       });
       // Ensure appUrl has protocol
       appUrl = userInput.includes("://") ? userInput : `https://${userInput}`;
-    } else if (hasWebSmithBaseUrl && ["new-pagekit", "new-pagekit-continue"].includes(choice)) {
+    } else if (["new-pagekit", "new-pagekit-continue"].includes(choice)) {
       // Deploy a new Pages Kit service
       try {
         let id = "";

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@aigne/core": "^1.61.0",
     "@aigne/gemini": "^0.14.0",
     "@aigne/openai": "^0.16.0",
+    "@blocklet/payment-broker-client": "^1.20.20",
     "chalk": "^5.5.0",
     "dompurify": "^3.2.6",
     "fs-extra": "^11.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@aigne/core": "^1.61.0",
     "@aigne/gemini": "^0.14.0",
     "@aigne/openai": "^0.16.0",
-    "@blocklet/payment-broker-client": "^1.20.20",
+    "@blocklet/payment-broker-client": "^1.21.1",
     "chalk": "^5.5.0",
     "dompurify": "^3.2.6",
     "fs-extra": "^11.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(@libsql/client@0.15.15)(@types/node@24.0.15)(chokidar@3.6.0)(ws@8.18.3)
       '@blocklet/payment-broker-client':
-        specifier: ^1.20.20
+        specifier: ^1.21.1
         version: 1.21.1
       chalk:
         specifier: ^5.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@aigne/openai':
         specifier: ^0.16.0
         version: 0.16.0(@libsql/client@0.15.15)(@types/node@24.0.15)(chokidar@3.6.0)(ws@8.18.3)
+      '@blocklet/payment-broker-client':
+        specifier: ^1.20.20
+        version: 1.21.1
       chalk:
         specifier: ^5.5.0
         version: 5.6.2
@@ -397,6 +400,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blocklet/payment-broker-client@1.21.1':
+    resolution: {integrity: sha512-WFJRox+sfORCoCPDFXm+fRvRopw487CAZD+86c+pcBRs5VpkNQtSrH9AquzM4kL5cfem2dWfNkn4/gNJIITdPg==}
+    engines: {node: '>=14.0.0'}
 
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
@@ -5372,6 +5379,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.1.4':
     optional: true
+
+  '@blocklet/payment-broker-client@1.21.1': {}
 
   '@braintree/sanitize-url@7.1.1': {}
 

--- a/tests/utils/deploy.test.mjs
+++ b/tests/utils/deploy.test.mjs
@@ -330,7 +330,7 @@ describe("deploy", () => {
     expect(result.homeUrl).toBe(TEST_HOME_URL);
   });
 
-  test("uses custom BASE_URL when WEB_SMITH_BASE_URL is set", async () => {
+  test("uses default staging URL even when WEB_SMITH_BASE_URL is set", async () => {
     process.env.WEB_SMITH_BASE_URL = "https://custom.websmith.test";
 
     const mockResult = {
@@ -352,7 +352,7 @@ describe("deploy", () => {
     );
   });
 
-  test("uses empty BASE_URL when WEB_SMITH_BASE_URL is not set", async () => {
+  test("uses default staging URL when WEB_SMITH_BASE_URL is not set", async () => {
     delete process.env.WEB_SMITH_BASE_URL;
 
     const mockResult = {

--- a/tests/utils/deploy.test.mjs
+++ b/tests/utils/deploy.test.mjs
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as openModule from "open";
+import * as authUtilsModule from "../../utils/auth-utils.mjs";
+
+// Import the deploy function
+import { deploy } from "../../utils/deploy.mjs";
+import * as utilsModule from "../../utils/utils.mjs";
+
+const TEST_HOME_URL = "https://pagekit-test.websmith.aigne.io";
+const TEST_APP_URL = "https://pagekit-app-test.websmith.aigne.io";
+const TEST_DASHBOARD_URL = "https://pagekit-dashboard-test.websmith.aigne.io";
+const TEST_SUBSCRIPTION_URL = "https://pagekit-subscription-test.websmith.aigne.io";
+
+// Mock BrokerClient
+const mockBrokerClient = {
+  deploy: mock(),
+};
+
+const mockBrokerClientConstructor = mock(() => mockBrokerClient);
+
+// Mock the payment broker client module
+mock.module("@blocklet/payment-broker-client/node", () => ({
+  BrokerClient: mockBrokerClientConstructor,
+  STEPS: {
+    PAYMENT_PENDING: "PAYMENT_PENDING",
+    INSTALLATION_STARTING: "INSTALLATION_STARTING",
+    SERVICE_STARTING: "SERVICE_STARTING",
+    ACCESS_PREPARING: "ACCESS_PREPARING",
+    ACCESS_READY: "ACCESS_READY",
+  },
+}));
+
+describe("deploy", () => {
+  let originalConsole;
+  let consoleOutput;
+  let getOfficialAccessTokenSpy;
+  let saveValueToConfigSpy;
+  let openDefaultSpy;
+
+  beforeEach(() => {
+    // Note: WEB_SMITH_BASE_URL is not set, so BASE_URL will be empty string
+
+    // Mock console to capture output
+    consoleOutput = [];
+    originalConsole = {
+      log: console.log,
+      error: console.error,
+    };
+    console.log = (...args) => consoleOutput.push({ type: "log", args });
+    console.error = (...args) => consoleOutput.push({ type: "error", args });
+
+    // Mock dependencies
+    getOfficialAccessTokenSpy = spyOn(authUtilsModule, "getOfficialAccessToken").mockResolvedValue(
+      "mock-auth-token",
+    );
+    saveValueToConfigSpy = spyOn(utilsModule, "saveValueToConfig").mockResolvedValue();
+    openDefaultSpy = spyOn(openModule, "default").mockResolvedValue();
+
+    // Reset mocks
+    mockBrokerClientConstructor.mockClear();
+    mockBrokerClient.deploy.mockClear();
+  });
+
+  afterEach(() => {
+    // Restore console
+    console.log = originalConsole.log;
+    console.error = originalConsole.error;
+
+    // Restore all spies
+    getOfficialAccessTokenSpy?.mockRestore();
+    saveValueToConfigSpy?.mockRestore();
+    openDefaultSpy?.mockRestore();
+
+    // Clean up environment
+    delete process.env.NODE_ENV;
+    delete process.env.WEB_SMITH_BASE_URL;
+  });
+
+  test("successful deployment flow", async () => {
+    // Mock successful deployment result
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      dashboardUrl: TEST_DASHBOARD_URL,
+      subscriptionUrl: TEST_SUBSCRIPTION_URL,
+      vendors: [{ token: "pagekit-auth-token-123" }],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    const result = await deploy();
+
+    // Verify BrokerClient was constructed with correct config
+    expect(mockBrokerClientConstructor).toHaveBeenCalledWith({
+      baseUrl: "https://staging.websmith.aigne.io",
+      authToken: "mock-auth-token",
+      paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+    });
+
+    // Verify deploy was called with correct parameters
+    expect(mockBrokerClient.deploy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cachedCheckoutId: undefined,
+        cachedPaymentUrl: undefined,
+        pageInfo: expect.objectContaining({
+          successMessage: expect.objectContaining({
+            en: expect.stringContaining(
+              "Congratulations! Your website has been successfully created",
+            ),
+            zh: expect.stringContaining("恭喜您，你的网站已创建成功"),
+          }),
+        }),
+        hooks: expect.objectContaining({
+          PAYMENT_PENDING: expect.any(Function),
+          INSTALLATION_STARTING: expect.any(Function),
+          SERVICE_STARTING: expect.any(Function),
+          ACCESS_PREPARING: expect.any(Function),
+          ACCESS_READY: expect.any(Function),
+        }),
+        onError: expect.any(Function),
+      }),
+    );
+
+    // Verify result transformation
+    expect(result).toEqual({
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      dashboardUrl: TEST_DASHBOARD_URL,
+      subscriptionUrl: TEST_SUBSCRIPTION_URL,
+      token: "pagekit-auth-token-123",
+    });
+
+    // Verify console output
+    const logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("🚀 Starting deployment..."))).toBe(true);
+  });
+
+  test("successful deployment with cached parameters", async () => {
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      vendors: [{ token: "pagekit-auth-token-123" }],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    const result = await deploy("cached-checkout-id", "https://cached-payment.url");
+
+    // Verify deploy was called with cached parameters
+    expect(mockBrokerClient.deploy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cachedCheckoutId: "cached-checkout-id",
+        cachedPaymentUrl: "https://cached-payment.url",
+      }),
+    );
+
+    expect(result.appUrl).toBe(TEST_APP_URL);
+    expect(result.token).toBe("pagekit-auth-token-123");
+  });
+
+  test("handles missing auth token", async () => {
+    getOfficialAccessTokenSpy.mockResolvedValue(null);
+
+    await expect(deploy()).rejects.toThrow("Failed to get official access token");
+
+    // Verify BrokerClient was not created
+    expect(mockBrokerClientConstructor).not.toHaveBeenCalled();
+  });
+
+  test("handles BrokerClient deployment failure", async () => {
+    const deployError = new Error("Website deployment failed");
+    mockBrokerClient.deploy.mockRejectedValue(deployError);
+
+    await expect(deploy()).rejects.toThrow("Website deployment failed");
+
+    // Verify BrokerClient was created and deploy was called
+    expect(mockBrokerClientConstructor).toHaveBeenCalled();
+    expect(mockBrokerClient.deploy).toHaveBeenCalled();
+  });
+
+  test("PAYMENT_PENDING hook functionality", async () => {
+    let paymentPendingHook;
+
+    mockBrokerClient.deploy.mockImplementation(async (config) => {
+      paymentPendingHook = config.hooks.PAYMENT_PENDING;
+      return {
+        appUrl: TEST_APP_URL,
+        vendors: [{ token: "test-token" }],
+      };
+    });
+
+    await deploy();
+
+    // Test the PAYMENT_PENDING hook
+    await paymentPendingHook({
+      sessionId: "session-123",
+      paymentUrl: "https://payment.test/session-123",
+      isResuming: false,
+    });
+
+    // Verify saveValueToConfig was called
+    expect(saveValueToConfigSpy).toHaveBeenCalledWith(
+      "checkoutId",
+      "session-123",
+      "Checkout ID for website deployment service",
+    );
+    expect(saveValueToConfigSpy).toHaveBeenCalledWith(
+      "paymentUrl",
+      "https://payment.test/session-123",
+      "Payment URL for website deployment service",
+    );
+
+    // Verify browser was opened
+    expect(openDefaultSpy).toHaveBeenCalledWith("https://payment.test/session-123");
+
+    // Verify console output
+    const logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("⏳ Step 1/4: Waiting for payment..."))).toBe(true);
+    expect(logs.some((log) => log.includes("🔗 Payment link:"))).toBe(true);
+  });
+
+  test("PAYMENT_PENDING hook with isResuming=true", async () => {
+    let paymentPendingHook;
+
+    mockBrokerClient.deploy.mockImplementation(async (config) => {
+      paymentPendingHook = config.hooks.PAYMENT_PENDING;
+      return {
+        appUrl: TEST_APP_URL,
+        vendors: [{ token: "test-token" }],
+      };
+    });
+
+    await deploy();
+
+    // Test the PAYMENT_PENDING hook with isResuming=true
+    await paymentPendingHook({
+      sessionId: "session-123",
+      paymentUrl: "https://payment.test/session-123",
+      isResuming: true,
+    });
+
+    // Verify browser was NOT opened when resuming
+    expect(openDefaultSpy).not.toHaveBeenCalled();
+
+    // But saveValueToConfig should still be called
+    expect(saveValueToConfigSpy).toHaveBeenCalledWith(
+      "checkoutId",
+      "session-123",
+      "Checkout ID for website deployment service",
+    );
+  });
+
+  test("other hooks functionality", async () => {
+    let hooks;
+
+    mockBrokerClient.deploy.mockImplementation(async (config) => {
+      hooks = config.hooks;
+      return {
+        appUrl: TEST_APP_URL,
+        vendors: [{ token: "test-token" }],
+      };
+    });
+
+    await deploy();
+
+    // Test INSTALLATION_STARTING hook
+    hooks.INSTALLATION_STARTING();
+    let logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("📦 Step 2/4: Setting up your website..."))).toBe(true);
+
+    // Test SERVICE_STARTING hook
+    hooks.SERVICE_STARTING();
+    logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("🚀 Step 3/4: Starting your website..."))).toBe(true);
+
+    // Test ACCESS_PREPARING hook
+    hooks.ACCESS_PREPARING();
+    logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("🌐 Step 4/4: Getting your website URL..."))).toBe(true);
+
+    // Test ACCESS_READY hook without subscription
+    await hooks.ACCESS_READY({
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+    });
+    logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("🔗 Your website is ready at:"))).toBe(true);
+    expect(logs.some((log) => log.includes(TEST_HOME_URL))).toBe(true);
+
+    // Test ACCESS_READY hook with subscription
+    await hooks.ACCESS_READY({
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      subscriptionUrl: TEST_SUBSCRIPTION_URL,
+    });
+    logs = consoleOutput.filter((o) => o.type === "log").map((o) => o.args.join(" "));
+    expect(logs.some((log) => log.includes("🔗 Manage your subscription at:"))).toBe(true);
+    expect(logs.some((log) => log.includes(TEST_SUBSCRIPTION_URL))).toBe(true);
+  });
+
+  test("handles missing vendors in result", async () => {
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      vendors: null,
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    const result = await deploy();
+
+    expect(result.token).toBeUndefined();
+    expect(result.appUrl).toBe(TEST_APP_URL);
+    expect(result.homeUrl).toBe(TEST_HOME_URL);
+  });
+
+  test("handles empty vendors array in result", async () => {
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      homeUrl: TEST_HOME_URL,
+      vendors: [],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    const result = await deploy();
+
+    expect(result.token).toBeUndefined();
+    expect(result.appUrl).toBe(TEST_APP_URL);
+    expect(result.homeUrl).toBe(TEST_HOME_URL);
+  });
+
+  test("uses custom BASE_URL when WEB_SMITH_BASE_URL is set", async () => {
+    process.env.WEB_SMITH_BASE_URL = "https://custom.websmith.test";
+
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      vendors: [{ token: "test-token" }],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    await deploy();
+
+    // Verify BrokerClient was constructed with custom baseUrl
+    expect(mockBrokerClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: "mock-auth-token",
+        baseUrl: "https://staging.websmith.aigne.io",
+        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+      }),
+    );
+  });
+
+  test("uses empty BASE_URL when WEB_SMITH_BASE_URL is not set", async () => {
+    delete process.env.WEB_SMITH_BASE_URL;
+
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      vendors: [{ token: "test-token" }],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    await deploy();
+
+    // Verify BrokerClient was constructed with empty baseUrl
+    expect(mockBrokerClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: "mock-auth-token",
+        baseUrl: "https://staging.websmith.aigne.io",
+        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+      }),
+    );
+  });
+
+  test("handles browser opening failure", async () => {
+    openDefaultSpy.mockRejectedValue(new Error("Cannot open browser"));
+
+    let paymentPendingHook;
+    mockBrokerClient.deploy.mockImplementation(async (config) => {
+      paymentPendingHook = config.hooks.PAYMENT_PENDING;
+      return {
+        appUrl: TEST_APP_URL,
+        vendors: [{ token: "test-token" }],
+      };
+    });
+
+    await deploy();
+
+    // The hook should throw when browser opening fails (expected behavior)
+    await expect(
+      paymentPendingHook({
+        sessionId: "session-123",
+        paymentUrl: "https://payment.test/session-123",
+        isResuming: false,
+      }),
+    ).rejects.toThrow("Cannot open browser");
+
+    // Config should still be saved
+    expect(saveValueToConfigSpy).toHaveBeenCalled();
+  });
+
+  test("handles saveValueToConfig failure", async () => {
+    saveValueToConfigSpy.mockRejectedValue(new Error("Config save failed"));
+
+    let paymentPendingHook;
+    mockBrokerClient.deploy.mockImplementation(async (config) => {
+      paymentPendingHook = config.hooks.PAYMENT_PENDING;
+      return {
+        appUrl: TEST_APP_URL,
+        vendors: [{ token: "test-token" }],
+      };
+    });
+
+    await deploy();
+
+    // The hook should throw when config saving fails (expected behavior)
+    await expect(
+      paymentPendingHook({
+        sessionId: "session-123",
+        paymentUrl: "https://payment.test/session-123",
+        isResuming: false,
+      }),
+    ).rejects.toThrow("Config save failed");
+  });
+
+  test("includes paymentLinkKey in BrokerClient config", async () => {
+    const mockResult = {
+      appUrl: TEST_APP_URL,
+      vendors: [{ token: "test-token" }],
+    };
+
+    mockBrokerClient.deploy.mockResolvedValue(mockResult);
+
+    await deploy();
+
+    // Verify BrokerClient was constructed with paymentLinkKey
+    expect(mockBrokerClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+      }),
+    );
+  });
+});

--- a/tests/utils/deploy.test.mjs
+++ b/tests/utils/deploy.test.mjs
@@ -94,7 +94,7 @@ describe("deploy", () => {
     expect(mockBrokerClientConstructor).toHaveBeenCalledWith({
       baseUrl: "https://staging.websmith.aigne.io",
       authToken: "mock-auth-token",
-      paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+      paymentLinkKey: "WEB_SMITH_PAYMENT_LINK_ID",
     });
 
     // Verify deploy was called with correct parameters
@@ -347,7 +347,7 @@ describe("deploy", () => {
       expect.objectContaining({
         authToken: "mock-auth-token",
         baseUrl: "https://staging.websmith.aigne.io",
-        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+        paymentLinkKey: "WEB_SMITH_PAYMENT_LINK_ID",
       }),
     );
   });
@@ -369,7 +369,7 @@ describe("deploy", () => {
       expect.objectContaining({
         authToken: "mock-auth-token",
         baseUrl: "https://staging.websmith.aigne.io",
-        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+        paymentLinkKey: "WEB_SMITH_PAYMENT_LINK_ID",
       }),
     );
   });
@@ -438,7 +438,7 @@ describe("deploy", () => {
     // Verify BrokerClient was constructed with paymentLinkKey
     expect(mockBrokerClientConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
-        paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+        paymentLinkKey: "WEB_SMITH_PAYMENT_LINK_ID",
       }),
     );
   });

--- a/utils/auth-utils.mjs
+++ b/utils/auth-utils.mjs
@@ -67,7 +67,7 @@ export async function getAccessToken(appUrl, ltToken = "") {
         `${chalk.yellow("⚠️  The provided URL is not a valid website on ArcBlock platform")}\n\n` +
           `${chalk.bold(
             "💡 Solution:",
-          )} Start here to set up your own website for hosting pages:\n${storeLink}\n\n`,
+          )} Start here to set up your own website to host pages:\n${storeLink}\n\n`,
       );
     } else if (error instanceof ComponentNotFoundError) {
       const pagesLink = chalk.cyan(BLOCKLET_ADD_COMPONENT_PAGES);
@@ -156,7 +156,7 @@ export async function getAccessToken(appUrl, ltToken = "") {
 export async function getOfficialAccessToken(baseUrl) {
   // Early parameter validation
   if (!baseUrl) {
-    throw new Error("baseUrl parameter is required for getOfficialAccessToken.");
+    throw new Error("The baseUrl parameter is required for getting the official access token.");
   }
 
   // Parse URL once and reuse
@@ -218,7 +218,7 @@ export async function getOfficialAccessToken(baseUrl) {
   } catch (error) {
     console.debug(error);
     throw new Error(
-      "Failed to obtain official access token. Please check your network connection and try again later.",
+      "Failed to obtain the official access token. Please verify your network connection and permissions before trying again.",
     );
   }
 
@@ -258,7 +258,7 @@ async function saveTokenToConfigFile(configFile, hostname, tokenKey, tokenValue)
       }),
     );
   } catch (error) {
-    console.warn(`Failed to save token to config file: ${error.message}`, error);
-    // Don't throw here, as the token is already obtained and set in env
+    console.warn(`Failed to save access token to configuration file: ${error.message}`, error);
+    // Don't throw since token is already obtained and set in environment
   }
 }

--- a/utils/auth-utils.mjs
+++ b/utils/auth-utils.mjs
@@ -32,18 +32,18 @@ export async function getAccessToken(appUrl, ltToken = "") {
   const WEB_SMITH_ENV_FILE = join(homedir(), ".aigne", "web-smith-connected.yaml");
   const { hostname } = new URL(appUrl);
 
-  let accessToken = process.env.PAGE_KIT_ACCESS_TOKEN;
+  let accessToken = process.env.PAGES_KIT_ACCESS_TOKEN;
 
   // Check if access token exists in environment or config file
   if (!accessToken) {
     try {
       if (existsSync(WEB_SMITH_ENV_FILE)) {
         const data = await readFile(WEB_SMITH_ENV_FILE, "utf8");
-        if (data.includes("PAGE_KIT_ACCESS_TOKEN")) {
+        if (data.includes("PAGES_KIT_ACCESS_TOKEN")) {
           // Handle empty or invalid YAML files
           const envs = data.trim() ? parse(data) : null;
-          if (envs?.[hostname]?.PAGE_KIT_ACCESS_TOKEN) {
-            accessToken = envs[hostname].PAGE_KIT_ACCESS_TOKEN;
+          if (envs?.[hostname]?.PAGES_KIT_ACCESS_TOKEN) {
+            accessToken = envs[hostname].PAGES_KIT_ACCESS_TOKEN;
           }
         }
       }
@@ -113,7 +113,7 @@ export async function getAccessToken(appUrl, ltToken = "") {
     });
 
     accessToken = result.accessKeySecret;
-    process.env.PAGE_KIT_ACCESS_TOKEN = accessToken;
+    process.env.PAGES_KIT_ACCESS_TOKEN = accessToken;
 
     // Save the access token to config file
     const aigneDir = join(homedir(), ".aigne");
@@ -133,8 +133,8 @@ export async function getAccessToken(appUrl, ltToken = "") {
       stringify({
         ...existingConfig,
         [hostname]: {
-          PAGE_KIT_ACCESS_TOKEN: accessToken,
-          PAGE_KIT_URL: PAGES_KIT_URL,
+          PAGES_KIT_ACCESS_TOKEN: accessToken,
+          PAGES_KIT_URL: PAGES_KIT_URL,
         },
       }),
     );

--- a/utils/constants.mjs
+++ b/utils/constants.mjs
@@ -360,6 +360,9 @@ export const PAGES_KIT_STORE_URL =
 export const BLOCKLET_ADD_COMPONENT_PAGES =
   "https://www.arcblock.io/docs/blocklet-developer/en/7zbw0GQXgcD6sCcjVfwqqT2s";
 
+// Official access token environment variable name
+export const WEB_OFFICIAL_ACCESS_TOKEN = "WEB_OFFICIAL_ACCESS_TOKEN";
+
 // Supported file extensions for content reading
 export const SUPPORTED_FILE_EXTENSIONS = [".txt", ".md", ".json", ".yaml", ".yml"];
 

--- a/utils/constants.mjs
+++ b/utils/constants.mjs
@@ -360,7 +360,7 @@ export const PAGES_KIT_STORE_URL =
 export const BLOCKLET_ADD_COMPONENT_PAGES =
   "https://www.arcblock.io/docs/blocklet-developer/en/7zbw0GQXgcD6sCcjVfwqqT2s";
 
-// Official access token environment variable name
+// Environment variable name for the official API access token used for authentication
 export const WEB_OFFICIAL_ACCESS_TOKEN = "WEB_OFFICIAL_ACCESS_TOKEN";
 
 // Supported file extensions for content reading

--- a/utils/deploy.mjs
+++ b/utils/deploy.mjs
@@ -2,11 +2,15 @@ import { BrokerClient, STEPS } from "@blocklet/payment-broker-client/node";
 import chalk from "chalk";
 import open from "open";
 import { getOfficialAccessToken } from "./auth-utils.mjs";
+import { DEFAULT_APP_URL } from "./constants.mjs";
 import { saveValueToConfig } from "./utils.mjs";
 
 // ==================== Configuration ====================
-const BASE_URL = process.env.WEB_SMITH_BASE_URL || "";
-
+const BASE_URL = process.env.WEB_SMITH_BASE_URL || DEFAULT_APP_URL;
+const SUCCESS_MESSAGE = {
+  en: "Congratulations! Your website has been successfully created. You can return to the command-line tool to continue publishing your pages.",
+  zh: "恭喜您，你的网站已创建成功！可以返回命令行工具继续发布你的页面！",
+};
 /**
  * Deploy a new website for your pages and return the installation URL
  * @param {string} id - Cached checkout ID (optional)
@@ -24,12 +28,6 @@ export async function deploy(id, cachedUrl) {
     baseUrl: BASE_URL,
     authToken,
     paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
-    timeout: 300000,
-    polling: {
-      interval: 3000,
-      maxAttempts: 100,
-      backoffStrategy: "linear",
-    },
   });
 
   console.log(`🚀 Starting deployment...`);
@@ -37,12 +35,7 @@ export async function deploy(id, cachedUrl) {
   const result = await client.deploy({
     cachedCheckoutId: id,
     cachedPaymentUrl: cachedUrl,
-    page_info: {
-      success_message: {
-        en: "Congratulations! Your website has been successfully created. You can return to the command-line tool to continue publishing your pages.",
-        zh: "恭喜您，你的网站已创建成功！可以返回命令行工具继续发布你的页面！",
-      },
-    },
+    pageInfo: { successMessage: SUCCESS_MESSAGE },
     hooks: {
       [STEPS.PAYMENT_PENDING]: async ({ sessionId, paymentUrl, isResuming }) => {
         console.log(`⏳ Step 1/4: Waiting for payment...`);

--- a/utils/deploy.mjs
+++ b/utils/deploy.mjs
@@ -27,7 +27,7 @@ export async function deploy(id, cachedUrl) {
   const client = new BrokerClient({
     baseUrl: BASE_URL,
     authToken,
-    paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+    paymentLinkKey: "WEB_SMITH_PAYMENT_LINK_ID",
   });
 
   console.log(`🚀 Starting deployment...`);

--- a/utils/deploy.mjs
+++ b/utils/deploy.mjs
@@ -1,0 +1,105 @@
+import { BrokerClient, STEPS } from "@blocklet/payment-broker-client/node";
+import chalk from "chalk";
+import open from "open";
+import { getOfficialAccessToken } from "./auth-utils.mjs";
+import { saveValueToConfig } from "./utils.mjs";
+
+// ==================== Configuration ====================
+const BASE_URL = process.env.WEB_SMITH_BASE_URL || "";
+
+/**
+ * Deploy a new website for your pages and return the installation URL
+ * @param {string} id - Cached checkout ID (optional)
+ * @param {string} cachedUrl - Cached payment URL (optional)
+ * @returns {Promise<Object>} - The deployment result with URLs
+ */
+export async function deploy(id, cachedUrl) {
+  const authToken = await getOfficialAccessToken(BASE_URL);
+
+  if (!authToken) {
+    throw new Error("Failed to get official access token");
+  }
+
+  const client = new BrokerClient({
+    baseUrl: BASE_URL,
+    authToken,
+    paymentLinkKey: "PAYMENT_LINK_ID_OF_PAGE_KIT",
+    timeout: 300000,
+    polling: {
+      interval: 3000,
+      maxAttempts: 100,
+      backoffStrategy: "linear",
+    },
+  });
+
+  console.log(`🚀 Starting deployment...`);
+
+  const result = await client.deploy({
+    cachedCheckoutId: id,
+    cachedPaymentUrl: cachedUrl,
+    page_info: {
+      success_message: {
+        en: "Congratulations! Your website has been successfully created. You can return to the command-line tool to continue publishing your pages.",
+        zh: "恭喜您，你的网站已创建成功！可以返回命令行工具继续发布你的页面！",
+      },
+    },
+    hooks: {
+      [STEPS.PAYMENT_PENDING]: async ({ sessionId, paymentUrl, isResuming }) => {
+        console.log(`⏳ Step 1/4: Waiting for payment...`);
+        console.log(`🔗 Payment link: ${chalk.cyan(paymentUrl)}\n`);
+
+        await saveValueToConfig(
+          "checkoutId",
+          sessionId,
+          "Checkout ID for website deployment service",
+        );
+        await saveValueToConfig(
+          "paymentUrl",
+          paymentUrl,
+          "Payment URL for website deployment service",
+        );
+
+        if (!isResuming) {
+          await open(paymentUrl);
+        }
+      },
+
+      [STEPS.INSTALLATION_STARTING]: () => {
+        console.log(`📦 Step 2/4: Setting up your website...`);
+      },
+
+      [STEPS.SERVICE_STARTING]: () => {
+        console.log(`🚀 Step 3/4: Starting your website...`);
+      },
+
+      [STEPS.ACCESS_PREPARING]: () => {
+        console.log(`🌐 Step 4/4: Getting your website URL...`);
+      },
+
+      [STEPS.ACCESS_READY]: async ({ appUrl, homeUrl, subscriptionUrl }) => {
+        console.log(`\n🔗 Your website is ready at: ${chalk.cyan(homeUrl || appUrl)}`);
+        if (subscriptionUrl) {
+          console.log(`🔗 Manage your subscription at: ${chalk.cyan(subscriptionUrl)}\n`);
+        } else {
+          console.log("");
+        }
+      },
+    },
+
+    onError: (error, step) => {
+      console.error(`${chalk.red("❌")} Website deployment failed at ${step || "unknown step"}:`);
+      console.error(`   ${error.message}`);
+    },
+  });
+
+  const { appUrl, homeUrl, subscriptionUrl, dashboardUrl, vendors } = result;
+  const token = vendors?.[0]?.token;
+
+  return {
+    appUrl,
+    homeUrl,
+    dashboardUrl,
+    subscriptionUrl,
+    token,
+  };
+}


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
- 集成 blocklet/payment-broker-client 来一键新建并发布 pages kit
- 使用默认的 DEFAULT_APP_URL 来发布 （ 目前指向 https://staging.websmith.aigne.io ）
- 可以使用 `WEB_SMITH_BASE_URL` 环境变量来临时修改官网地址

### Screenshots
 
<img width="1464" height="889" alt="image" src="https://github.com/user-attachments/assets/aa84a971-e12f-40b9-8b3b-42a7eddbd5fc" />

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

🚀 Release Notes:

New Feature:
- Added official payment-based website deployment system
- Integrated secure token management for authentication
- Enhanced configuration options for staging environments

Test:
- Added comprehensive test coverage for deployment flows

This release introduces a streamlined website deployment process with integrated payment handling. Users can now deploy their websites through a secure, payment-enabled system with improved authentication. The update includes enhanced configuration options for different deployment environments, making the deployment process more robust and user-friendly.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->