### PR TITLE
fix: auto include media files in page datasources

### DIFF
--- a/agents/init/index.mjs
+++ b/agents/init/index.mjs
@@ -393,6 +393,9 @@ export function generateYAML(input) {
     // Paths
     pagesDir: input.pagesDir || "./aigne/web-smith/pages",
     sourcesPath: input.sourcesPath || [],
+
+    // Default datasources to include in every page
+    defaultDatasources: input.defaultDatasources || ["./media.md"],
   };
 
   // Generate comments and structure
@@ -492,6 +495,12 @@ export function generateYAML(input) {
     sourcesPath: config.sourcesPath,
   }).trim();
   yaml += `${sourcesPathSection.replace(/^sourcesPath:/, "sourcesPath:  # Source code paths to analyze")}\n`;
+
+  // Default datasources included in every page
+  const defaultDatasourcesSection = yamlStringify({
+    defaultDatasources: config.defaultDatasources,
+  }).trim();
+  yaml += `${defaultDatasourcesSection.replace(/^defaultDatasources:/, "defaultDatasources:  # Default datasources included in every page")}\n`;
 
   return yaml;
 }

--- a/agents/schema/website-structure.yaml
+++ b/agents/schema/website-structure.yaml
@@ -16,7 +16,9 @@ items:
       description: Parent node path, null for top-level
     sourceIds:
       type: array
-      description: Associated sourceIds from datasources, cannot be empty
+      description: |
+        Associated sourceIds from datasources, cannot be empty
+        **For each page, you must include as sourceIds the files that contain media resource descriptions or screenshot information.**
       items:
         type: string
   required:

--- a/agents/utils/transform-detail-datasources.mjs
+++ b/agents/utils/transform-detail-datasources.mjs
@@ -20,7 +20,7 @@ export default function transformDetailDatasources({ sourceIds, datasourcesList 
       const relativeId = toRelativePath(id);
       return `// sourceId: ${relativeId}\n${dsMap[normalizedId]}\n\n`;
     });
-  
+
   // Use all media.md files as datasources for each page
   const mediaFiles = (datasourcesList || []).filter((ds) => {
     return ds.sourceId.endsWith(".md") && ds.sourceId.includes("media.md");

--- a/agents/utils/transform-detail-datasources.mjs
+++ b/agents/utils/transform-detail-datasources.mjs
@@ -23,7 +23,7 @@ export default function transformDetailDatasources({ sourceIds, datasourcesList 
 
   // Use all media.md files as datasources for each page
   const mediaFiles = (datasourcesList || []).filter((ds) => {
-    return ds.sourceId.endsWith(".md") && ds.sourceId.includes("media.md");
+    return ds.sourceId.toLowerCase().endsWith("media.md");
   });
   mediaFiles.forEach((file) => {
     contents.push(`// sourceId: ${file.sourceId}\n${file.content}\n\n`);

--- a/agents/utils/transform-detail-datasources.mjs
+++ b/agents/utils/transform-detail-datasources.mjs
@@ -20,6 +20,14 @@ export default function transformDetailDatasources({ sourceIds, datasourcesList 
       const relativeId = toRelativePath(id);
       return `// sourceId: ${relativeId}\n${dsMap[normalizedId]}\n\n`;
     });
+  
+  // Use all media.md files as datasources for each page
+  const mediaFiles = (datasourcesList || []).filter((ds) => {
+    return ds.sourceId.endsWith(".md") && ds.sourceId.includes("media.md");
+  });
+  mediaFiles.forEach((file) => {
+    contents.push(`// sourceId: ${file.sourceId}\n${file.content}\n\n`);
+  });
 
   return { detailDataSources: contents.join("") };
 }

--- a/agents/utils/transform-detail-datasources.mjs
+++ b/agents/utils/transform-detail-datasources.mjs
@@ -1,6 +1,10 @@
 import { normalizePath, toRelativePath } from "../../utils/utils.mjs";
 
-export default function transformDetailDatasources({ defaultDatasources = [], sourceIds, datasourcesList }) {
+export default function transformDetailDatasources({
+  defaultDatasources = [],
+  sourceIds,
+  datasourcesList,
+}) {
   // Build a map for fast lookup, with path normalization for compatibility
   const dsMap = Object.fromEntries(
     (datasourcesList || []).map((ds) => {

--- a/prompts/common/rules/page-detail/resources-references-rules.md
+++ b/prompts/common/rules/page-detail/resources-references-rules.md
@@ -2,9 +2,12 @@
 
 - Media Resources
   - Use media **ONLY** from `<available_media_assets>` and copy each asset’s **`mediaKitPath`** exactly. Do **NOT** invent, paraphrase, or fabricate paths.
-  - Semantic fit: select media only when it clearly matches the section’s intent (topic, tone, purpose). Do **not** repurpose logos/brand marks, icons, illustrations, or product shots outside their intended context.
+  - Determine image placement based on:
+    - Information inferred from the image name
+    - Descriptions provided in the DataSource
+  - Semantic fit: select media only when it clearly matches the section’s intent (topic, tone, purpose). 
   - Deduplication: a real asset may appear **at most once** on the page (unless `<datasources>` explicitly requires otherwise).
-  - Prefer **non-media field combinations** if no suitable asset exists; do **not** force a fill.
+  - Prefer **non-media field combinations** if no suitable asset exists;
   - **Placeholder (last resort):** use a placeholder **only** when an image is **required for optimal presentation** (i.e., the layout is image-led), there is **no suitable asset** in `<available_media_assets>`, **and** there is **no approved non-media alternative** for that section.
     - Service: `https://placehold.co/{width}x{height}` (optional `?text=Preview`).
     - Defaults (keep aspect ratio):


### PR DESCRIPTION
## Related Issue

https://github.com/AIGNE-io/aigne-web-smith/issues/74

### Major Changes

1. 优化图片资源使用规则
  1.1 通过文件名、上下文描述，选择合适的位置使用图片
  1.2 没有合适的图片，可以不使用
2. 默认将 media.md 文件作为所有页面生成的上下文 ，可在 config.yaml 中修改默认包含的文件

### Screenshots

`init` 命令生成配置文件时，写入默认每个页面都包含的文件 `defaultDatasources`

<img width="1344" height="742" alt="image" src="https://github.com/user-attachments/assets/7c73f75f-0a42-4b0b-849a-029dd29ebce7" />

修改配置，`defaultDatasources` 加入其他文件
<img width="592" height="226" alt="image" src="https://github.com/user-attachments/assets/ff8bdbf3-0b4c-4559-bc70-dc0851b45af6" />


launcher 生成页面：
   https://staging.websmith.aigne.io/launcherv3/features
   https://staging.websmith.aigne.io/launcherv3/getting-started
   https://staging.websmith.aigne.io/launcherv3
   https://staging.websmith.aigne.io/launcherv3/support

相关代码：https://github.com/blocklet/launcher/tree/chore-web-pages

观察结果：
- 使用的图片的位置，都是 section 描述相关
- 使用图片的地方变少了，不使用在无关的位置

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- New Feature: Automatically includes media-related content from `media.md` files as datasources for each page, providing enhanced media integration capabilities
- Performance Note: Users working with large numbers of media files may experience slightly longer page load times

The update streamlines the process of incorporating media content across pages by automatically detecting and including relevant media markdown files. This change simplifies content management by eliminating the need to manually specify media datasources for each page.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->