### PR TITLE
fix: persist project ID and slug after self-hosted publish

### DIFF
--- a/agents/publish/publish-website.mjs
+++ b/agents/publish/publish-website.mjs
@@ -203,6 +203,7 @@ export default async function publishWebsite(
 
   let shouldWithLocales = withLocalesOption || false;
   let shouldWithNavigations = withNavigationsOption || false;
+  let publishToSelfHostedBlocklet = false;
 
   let token = "";
 
@@ -255,9 +256,12 @@ export default async function publishWebsite(
       // Ensure appUrl has protocol
       appUrl = userInput.includes("://") ? userInput : `https://${userInput}`;
     } else if (["new-pages-kit", "new-pages-kit-continue"].includes(choice)) {
+      publishToSelfHostedBlocklet = true;
+
       // upload to default project
       config.projectId = DEFAULT_PROJECT_ID;
       config.projectSlug = DEFAULT_PROJECT_SLUG;
+
       projectId = DEFAULT_PROJECT_ID;
       projectSlug = DEFAULT_PROJECT_SLUG;
 
@@ -591,13 +595,15 @@ export default async function publishWebsite(
         await saveValueToConfig("appUrl", appUrl);
       }
 
-      const shouldSaveProjectId = !hasProjectIdInConfig || projectId !== newProjectId;
+      const shouldSaveProjectId =
+        !hasProjectIdInConfig || projectId !== newProjectId || publishToSelfHostedBlocklet;
       if (shouldSaveProjectId) {
         await saveValueToConfig("projectId", newProjectId || projectId);
       }
 
       const shouldSaveProjectSlug =
-        !!newProjectSlug && (!hasProjectSlugInConfig || projectSlug !== newProjectSlug);
+        !!newProjectSlug &&
+        (!hasProjectSlugInConfig || projectSlug !== newProjectSlug || publishToSelfHostedBlocklet);
       if (shouldSaveProjectSlug) {
         await saveValueToConfig("projectSlug", newProjectSlug);
       }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

- 修复 publish 到 self-hosted 没有回填  config 问题

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist


<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- New Feature: Added support for publishing to self-hosted blocklet instances, giving users more flexibility in deployment options
- Chore: Enhanced configuration management for project IDs and slugs when publishing to different environments

The main update introduces the ability to publish to self-hosted blocklet instances, expanding deployment capabilities beyond the default options. This change improves the publishing workflow for users who maintain their own blocklet infrastructure.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->