### PR TITLE
fix: resolve the bug of download logo error

### DIFF
--- a/agents/publish/publish-website.mjs
+++ b/agents/publish/publish-website.mjs
@@ -622,9 +622,11 @@ export default async function publishWebsite(
             return;
           }
 
-          if (!ext) {
-            const contentType = response.headers.get("content-type");
-            ext = getExtnameFromContentType(contentType);
+          const contentType = response.headers.get("content-type");
+          const newExt = getExtnameFromContentType(contentType);
+
+          if (!ext || newExt !== ext) {
+            ext = newExt;
             tempFilePath = `${tempFilePath}.${ext}`;
           }
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like 'fixes', 'closes', 'resolves', or 'relates to' to link the issue. All PRs should ideally be associated with an issue. -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

1. 修复 download Project Logo 解析文件名问题
2. 略微重构 projectLogo 下载功能，使用中间变量 localProjectLogo，避免引入中间变更，导致出现 bug

### Screenshots

<!-- If the changes are related to the UI (CLI or web), screenshots should be included. -->

<img width="1688" height="2420" alt="QQ_1760623637237" src="https://github.com/user-attachments/assets/73f28c1b-143e-4fd4-8032-bf5a0517829b" />


### Test Plan

<!-- If this change is not covered by automated tests, describe your test cases as a to-do list below. -->

### Checklist


<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Bug Fix**: 
- Improved handling of project logo downloads and storage across cloud services
- Fixed URL processing for logo files by properly handling pathnames and query strings
- Enhanced file extension detection for project logos

These changes ensure more reliable logo management in media kits and cloud storage, reducing potential errors when processing project logos with complex URLs or non-standard file paths.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->